### PR TITLE
Force client-side catch on bad volunteers request

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -42,10 +42,10 @@ class VolunteersController < ApplicationController
       if @volunteer.save
         render :show, status: :created, location: @volunteer
       else
-        render json: @volunteer.errors, status: :unprocessable_entity
+        render json: { errors: @volunteer.errors }, status: :unprocessable_entity
       end
     else
-      render json: @volunteer.errors, status: :unprocessable_entity
+      render json: { errors: @volunteer.errors }, status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
  http://travisjeffery.com/b/2012/04/rendering-errors-in-json-with-rails/

A bad request wasn't triggering a client-side catch. The changes made here fix that issue according to the article author.